### PR TITLE
Make layers.py and utils.py compatible with keras 2.2

### DIFF
--- a/keras_compressor/layers.py
+++ b/keras_compressor/layers.py
@@ -326,7 +326,10 @@ class FactorizedConv2DTucker(Layer):
         self.kernel_size = conv_utils.normalize_tuple(kernel_size, rank, 'kernel_size')
         self.strides = conv_utils.normalize_tuple(strides, rank, 'strides')
         self.padding = conv_utils.normalize_padding(padding)
-        self.data_format = conv_utils.normalize_data_format(data_format)
+        if hasattr(conv_utils, 'normalize_data_format'):
+            self.data_format = conv_utils.normalize_data_format(data_format)
+        else:
+            self.data_format = K.normalize_data_format(data_format)
         self.dilation_rate = conv_utils.normalize_tuple(dilation_rate, rank, 'dilation_rate')
         self.activation = activations.get(activation)
         self.use_bias = use_bias

--- a/keras_compressor/utils.py
+++ b/keras_compressor/utils.py
@@ -20,7 +20,8 @@ def swap_layer_connection(old_layer: Layer, new_layer: Layer) -> None:
     inbound_layers = set()
 
     # create new inbound nodes
-    for node in old_layer.inbound_nodes:  # type: Node
+    for node in old_layer.inbound_nodes if hasattr(old_layer, 'inbound_nodes')\
+        else old_layer._inbound_nodes:  # type: Node
         Node(
             new_layer, node.inbound_layers,
             node.node_indices, node.tensor_indices,
@@ -34,15 +35,20 @@ def swap_layer_connection(old_layer: Layer, new_layer: Layer) -> None:
     for layer in inbound_layers:  # type: Layer
         old_nodes = filter(
             lambda n: n.outbound_layer == old_layer,
-            layer.outbound_nodes,
+            layer.outbound_nodes if hasattr(layer, 'outbound_nodes')\
+                else layer._outbound_nodes
         )
         for n in old_nodes:  # type: Node
-            layer.outbound_nodes.remove(n)
+            if hasattr(layer, 'outbound_nodes'):
+                layer.outbound_nodes.remove(n)
+            else:
+                layer._outbound_nodes.remove(n)
 
     # the set of outbound layer which have old inbound_nodes
     outbound_layers = set()
     # create new outbound nodes
-    for node in old_layer.outbound_nodes:  # type: Node
+    for node in old_layer.outbound_nodes if hasattr(old_layer, 'outbound_nodes')\
+        else old_layer._outbound_nodes:  # type: Node
         layers = list(node.inbound_layers)
         while old_layer in layers:
             idx = layers.index(old_layer)
@@ -60,10 +66,14 @@ def swap_layer_connection(old_layer: Layer, new_layer: Layer) -> None:
     for layer in outbound_layers:  # type: Layer
         old_nodes = filter(
             lambda n: old_layer in n.inbound_layers,
-            layer.inbound_nodes,
+            layer.inbound_nodes if hasattr(layer, 'inbound_nodes')\
+                else layer._inbound_nodes
         )
         for n in old_nodes:
-            layer.inbound_nodes.remove(n)
+            if hasattr(layer, 'inbound_nodes'):
+                layer.inbound_nodes.remove(n)
+            else:
+                layer._inbound_nodes.remove(n)
 
 
 def convert_config(


### PR DESCRIPTION
layers.py:
Keras 2.2 use layer._inbound_nodes, layer._outbound_nodes instead of layer.inbound_nodes, layer.outbound_nodes.
utils.py
conv_utils.normalize_data_format should be replaced with K.normalize_data_format in keras 2.2.

Ref: 
ekholabs/keras-contrib@0dac2da#diff-0970ecd5f755557421e7ba7716bdfd6a
https://github.com/apple/coremltools/blob/master/coremltools/converters/keras/_topology2.py